### PR TITLE
fix: correct deepspeed config

### DIFF
--- a/official/ai-ml/deepspeed.json
+++ b/official/ai-ml/deepspeed.json
@@ -2,37 +2,33 @@
   "name": "deepspeed",
   "description": "Complete DeepSpeed knowledge from official documentation. Use when training large-scale deep learning models with optimization. Covers ZeRO, mixed precision, pipeline parallelism, and inference.",
   "version": "1.0.0",
-  "base_url": "https://www.deepspeed.ai/docs/",
   "sources": [
     {
       "type": "documentation",
-      "base_url": "https://www.deepspeed.ai/docs/",
+      "base_url": "https://www.deepspeed.ai/",
       "start_urls": [
-        "https://www.deepspeed.ai/docs/",
         "https://www.deepspeed.ai/getting-started/",
         "https://www.deepspeed.ai/tutorials/",
         "https://www.deepspeed.ai/docs/config-json/"
       ],
       "selectors": {
-        "main_content": "article, main",
+        "main_content": "article, main, .page-content, #main-content",
         "title": "h1",
         "code_blocks": "pre code, pre"
       },
       "url_patterns": {
         "include": [
-          "/docs/",
           "/getting-started/",
           "/tutorials/",
-          "/tutorials/zero/",
-          "/tutorials/megatron/"
+          "/docs/config-json"
         ],
         "exclude": [
-          "/blog/"
+          "/blog/",
+          "/news/"
         ]
       },
       "categories": {
         "getting_started": [
-          "",
           "getting-started",
           "installation",
           "writing-apps"
@@ -70,15 +66,10 @@
           "transformer",
           "moe"
         ],
-        "activation_checkpointing": [
-          "activation-checkpointing",
-          "checkpoint-activations",
-          "cpu-offload"
-        ],
         "data_efficiency": [
           "tutorials/curriculum-learning",
           "data-efficiency",
-          " curriculum",
+          "curriculum",
           "data-sampling"
         ],
         "compression": [
@@ -106,8 +97,51 @@
           "logging"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.5,
+      "max_pages": 150
+    },
+    {
+      "type": "documentation",
+      "base_url": "https://deepspeed.readthedocs.io/en/latest/",
+      "start_urls": [
+        "https://deepspeed.readthedocs.io/en/latest/"
+      ],
+      "selectors": {
+        "main_content": ".document, article, main, [role='main']",
+        "title": "h1",
+        "code_blocks": "pre code, pre"
+      },
+      "url_patterns": {
+        "include": [
+          "/en/latest/"
+        ],
+        "exclude": [
+          "/_modules/",
+          "/_sources/",
+          "/genindex",
+          "/search"
+        ]
+      },
+      "categories": {
+        "api_reference": [
+          "initialize",
+          "inference-init",
+          "inference-engine",
+          "model-checkpointing",
+          "activation-checkpointing",
+          "zero3",
+          "moe",
+          "kernel",
+          "pipeline",
+          "optimizers",
+          "schedulers",
+          "flops-profiler",
+          "autotuning",
+          "training"
+        ]
+      },
+      "rate_limit": 0.5,
+      "max_pages": 100
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Issues Fixed

### Critical
- **404 base_url** — `https://www.deepspeed.ai/docs/` returns 404. Fixed to use `https://www.deepspeed.ai/` with proper include patterns
- **Empty category keyword** — `getting_started` had `""` (empty string) as a keyword, matching every URL
- **Whitespace keyword** — `data_efficiency` had `" curriculum"` with a leading space

### Improvements  
- Added second source: `https://deepspeed.readthedocs.io/en/latest/` (the official API reference, previously missing)
- Removed redundant top-level `base_url` (only valid in single-source configs)
- Tuned `max_pages` from 400 → 150+100 (more realistic for each source)
- Improved `rate_limit` from 0.3 → 0.5 (less aggressive)
- Improved `main_content` selector with fallback chain

### Validation
```
✅ Unified config valid: 2 sources
  1. Documentation: https://www.deepspeed.ai/      → HTTP 200
  2. Documentation: https://deepspeed.readthedocs.io/en/latest/  → HTTP 200
```