### PR TITLE
fix: review and update all 34 ai-ml configs

### DIFF
--- a/official/ai-ml/anthropic.json
+++ b/official/ai-ml/anthropic.json
@@ -1,7 +1,7 @@
 {
   "name": "anthropic",
-  "description": "Complete Anthropic API knowledge from official documentation. Use when building applications with Claude AI models. Covers Messages API, tool use, vision, streaming, and prompt engineering.",
-  "version": "1.0.0",
+  "description": "Complete Anthropic API knowledge from official documentation. Use when building applications with Claude AI models. Covers Messages API, tool use, vision, streaming, extended thinking, batch API, and prompt engineering.",
+  "version": "1.1.0",
   "base_url": "https://docs.anthropic.com/en/",
   "sources": [
     {
@@ -11,7 +11,10 @@
         "https://docs.anthropic.com/en/",
         "https://docs.anthropic.com/en/api/getting-started",
         "https://docs.anthropic.com/en/api/messages",
-        "https://docs.anthropic.com/en/docs/build-with-claude/overview"
+        "https://docs.anthropic.com/en/docs/build-with-claude/overview",
+        "https://docs.anthropic.com/en/docs/about-claude/models/overview",
+        "https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking",
+        "https://docs.anthropic.com/en/docs/build-with-claude/tool-use"
       ],
       "selectors": {
         "main_content": "article, main",
@@ -23,15 +26,16 @@
           "/en/api/",
           "/en/docs/",
           "/en/docs/build-with-claude/",
-          "/en/docs/test-and-evaluate/"
+          "/en/docs/test-and-evaluate/",
+          "/en/docs/about-claude/"
         ],
         "exclude": [
-          "/en/release-notes/"
+          "/en/release-notes/",
+          "/en/home"
         ]
       },
       "categories": {
         "getting_started": [
-          "",
           "api/getting-started",
           "api/sdk",
           "api/errors"
@@ -43,19 +47,28 @@
           "multi-turn"
         ],
         "models": [
-          "docs/models-overview",
-          "claude-3-5-sonnet",
-          "claude-3-opus",
-          "claude-3-haiku"
+          "docs/about-claude/models/overview",
+          "claude-opus-4",
+          "claude-sonnet-4",
+          "claude-haiku-4",
+          "claude-3-7-sonnet",
+          "claude-3-5-sonnet"
         ],
         "tool_use": [
-          "docs/tool-use",
+          "docs/build-with-claude/tool-use",
           "tool-use-overview",
           "computer-use",
-          "streaming-tool-use"
+          "streaming-tool-use",
+          "function-calling"
+        ],
+        "extended_thinking": [
+          "docs/build-with-claude/extended-thinking",
+          "thinking",
+          "reasoning",
+          "budget_tokens"
         ],
         "vision": [
-          "docs/vision",
+          "docs/build-with-claude/vision",
           "vision-examples",
           "image-processing",
           "pdf-support"
@@ -67,15 +80,33 @@
           "delta"
         ],
         "prompt_engineering": [
-          "docs/prompt-engineering",
+          "docs/build-with-claude/prompt-engineering",
           "prompt-examples",
-          "best-practices"
+          "best-practices",
+          "prompt-library"
         ],
         "tokens": [
-          "api/tokens",
+          "api/counting-tokens",
           "token-counting",
           "context-window",
           "max-tokens"
+        ],
+        "batch_api": [
+          "docs/build-with-claude/message-batches",
+          "batch",
+          "async",
+          "bulk-processing"
+        ],
+        "files_api": [
+          "docs/build-with-claude/files",
+          "file-uploads",
+          "pdf",
+          "documents"
+        ],
+        "prompt_caching": [
+          "docs/build-with-claude/prompt-caching",
+          "cache-control",
+          "ephemeral"
         ],
         "testing": [
           "docs/test-and-evaluate",
@@ -84,23 +115,23 @@
           "unit-testing"
         ],
         "citations": [
-          "docs/citations",
+          "docs/build-with-claude/citations",
           "grounding",
           "sources"
-        ],
-        "prompt_caching": [
-          "docs/prompt-caching",
-          "cache-control",
-          "ephemeral"
         ],
         "rate_limits": [
           "api/rate-limits",
           "limits",
           "tier-usage"
+        ],
+        "mcp": [
+          "docs/build-with-claude/mcp",
+          "model-context-protocol",
+          "servers",
+          "tools"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 300
+      "rate_limit": 0.3
     }
   ],
   "metadata": {
@@ -112,7 +143,8 @@
       "AI assistants",
       "Content generation",
       "Code generation",
-      "Vision applications"
+      "Vision applications",
+      "Agentic systems"
     ],
     "related_skills": [
       "python",

--- a/official/ai-ml/catboost.json
+++ b/official/ai-ml/catboost.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "concepts/about",
           "concepts/installation",
           "concepts/tutorials"
@@ -105,8 +104,7 @@
           "json"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 350
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/chroma.json
+++ b/official/ai-ml/chroma.json
@@ -1,7 +1,7 @@
 {
   "name": "chroma",
-  "description": "Complete Chroma knowledge from official documentation. Use when building AI-native embeddings databases. Collections, embeddings, querying, filtering, and multi-modal support.",
-  "version": "1.0.0",
+  "description": "Complete Chroma knowledge from official documentation. Use when building AI-native embeddings databases. Collections, embeddings, querying, filtering, multi-modal support, and client-server deployment.",
+  "version": "1.1.0",
   "base_url": "https://docs.trychroma.com/",
   "sources": [
     {
@@ -9,41 +9,42 @@
       "base_url": "https://docs.trychroma.com/",
       "start_urls": [
         "https://docs.trychroma.com/",
-        "https://docs.trychroma.com/getting-started",
-        "https://docs.trychroma.com/usage-guide",
-        "https://docs.trychroma.com/embeddings"
+        "https://docs.trychroma.com/docs/overview/introduction",
+        "https://docs.trychroma.com/docs/overview/getting-started",
+        "https://docs.trychroma.com/reference/py-client"
       ],
       "selectors": {
-        "main_content": "article, main",
+        "main_content": "article, main, [class*='content'], [class*='docs']",
         "title": "h1",
         "code_blocks": "pre code, pre"
       },
       "url_patterns": {
         "include": [
-          "/",
-          "/getting-started",
-          "/usage-guide",
-          "/embeddings",
-          "/integrations"
+          "/docs/",
+          "/reference/",
+          "/integrations/"
         ],
         "exclude": [
-          "/api-reference/"
+          "/blog/",
+          "/community/"
         ]
       },
       "categories": {
         "getting_started": [
-          "",
-          "getting-started",
+          "overview/introduction",
+          "overview/getting-started",
           "installation",
-          "introduction"
+          "quickstart"
         ],
         "collections": [
-          "usage-guide",
-          "creating-collection",
-          "getting-collection",
-          "deleting-collection"
+          "collections",
+          "create-collection",
+          "get-collection",
+          "delete-collection",
+          "collection-configuration"
         ],
         "documents": [
+          "usage-guide",
           "adding-data",
           "upsert",
           "add",
@@ -55,22 +56,26 @@
           "default-embeddings",
           "openai",
           "sentence-transformers",
+          "cohere",
           "custom"
         ],
         "querying": [
           "querying-collections",
           "query",
+          "get",
           "where",
-          "where_document"
+          "where_document",
+          "include"
         ],
-        "metadata": [
+        "metadata_filtering": [
           "metadata",
           "filtering",
           "operators",
           "and",
-          "or"
+          "or",
+          "contains"
         ],
-        "distance": [
+        "distance_metrics": [
           "distance",
           "cosine",
           "l2",
@@ -79,38 +84,40 @@
         ],
         "persistence": [
           "persistence",
-          "save",
-          "load",
-          "client",
-          "http-client"
+          "ephemeral-client",
+          "persistent-client",
+          "http-client",
+          "cloud-client"
         ],
-        "deployment": [
-          "deployment",
+        "client_server": [
+          "client-server",
+          "chroma-server",
           "docker",
-          "aws",
-          "gcp",
-          "azure"
+          "kubernetes",
+          "authentication"
         ],
         "integrations": [
           "integrations",
           "langchain",
           "llamaindex",
           "openai",
-          "huggingface"
+          "huggingface",
+          "haystack"
         ],
         "multi_modal": [
           "multi-modal",
           "images",
-          "data-loader"
+          "data-loader",
+          "CLIP"
         ],
-        "telemetry": [
-          "telemetry",
-          "analytics",
-          "opting-out"
+        "migration": [
+          "migration",
+          "upgrade",
+          "v0.4",
+          "v0.5"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 250
+      "rate_limit": 0.3
     }
   ],
   "metadata": {
@@ -122,7 +129,8 @@
       "Semantic search",
       "RAG",
       "AI applications",
-      "Local vector DB"
+      "Local vector DB",
+      "Multi-modal search"
     ],
     "related_skills": [
       "python",

--- a/official/ai-ml/cohere.json
+++ b/official/ai-ml/cohere.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "docs/the-cohere-platform",
           "quickstart",
           "authentication"
@@ -111,8 +110,7 @@
           "java"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 300
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/deepspeed.json
+++ b/official/ai-ml/deepspeed.json
@@ -2,6 +2,7 @@
   "name": "deepspeed",
   "description": "Complete DeepSpeed knowledge from official documentation. Use when training large-scale deep learning models with optimization. Covers ZeRO, mixed precision, pipeline parallelism, and inference.",
   "version": "1.0.0",
+  "base_url": "https://www.deepspeed.ai/",
   "sources": [
     {
       "type": "documentation",
@@ -97,8 +98,7 @@
           "logging"
         ]
       },
-      "rate_limit": 0.5,
-      "max_pages": 150
+      "rate_limit": 0.5
     },
     {
       "type": "documentation",
@@ -140,8 +140,7 @@
           "training"
         ]
       },
-      "rate_limit": 0.5,
-      "max_pages": 100
+      "rate_limit": 0.5
     }
   ],
   "metadata": {

--- a/official/ai-ml/dvc.json
+++ b/official/ai-ml/dvc.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "start",
           "install",
           "what-is-dvc"
@@ -103,8 +102,7 @@
           "partial"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/fastai.json
+++ b/official/ai-ml/fastai.json
@@ -33,7 +33,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "quick_start",
           "tutorial",
           "install"
@@ -104,8 +103,7 @@
           "dicom"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/gensim.json
+++ b/official/ai-ml/gensim.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "auto_examples/core/run_core_concepts",
           "install",
           "tutorials"
@@ -103,12 +102,11 @@
           "mmap"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 300
+      "rate_limit": 0.3
     }
   ],
   "metadata": {
-    "author": "Radim \u0158eh\u016f\u0159ek",
+    "author": "Radim Řehůřek",
     "language": "Python",
     "framework_type": "Topic Modeling Library",
     "use_cases": [

--- a/official/ai-ml/huggingface.json
+++ b/official/ai-ml/huggingface.json
@@ -79,7 +79,7 @@
           "lora",
           "qlora",
           "prompt_tuning",
-          " adapters"
+          "adapters"
         ],
         "trl": [
           "trl",
@@ -110,8 +110,7 @@
           "multi_gpu"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 600
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/jax.json
+++ b/official/ai-ml/jax.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "notebooks/quickstart",
           "installation",
           "key-concepts"
@@ -115,8 +114,7 @@
           "errors"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/keras.json
+++ b/official/ai-ml/keras.json
@@ -25,13 +25,10 @@
           "/api/",
           "/examples/"
         ],
-        "exclude": [
-          "/keras_3/"
-        ]
+        "exclude": []
       },
       "categories": {
         "getting_started": [
-          "",
           "getting_started",
           "introduction_to_keras",
           "ecosystem"
@@ -114,8 +111,7 @@
           "custom_training_loop"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/kubeflow.json
+++ b/official/ai-ml/kubeflow.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "started",
           "installing-kubeflow",
           "getting-started"
@@ -103,8 +102,7 @@
           "pipelines/pipelines-multi-user"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/langchain.json
+++ b/official/ai-ml/langchain.json
@@ -1,18 +1,18 @@
 {
   "name": "langchain",
-  "description": "Complete LangChain knowledge from official documentation. Use when building LLM-powered applications with chains, agents, and RAG. Covers LangChain Python/JS, LCEL, and integration with OpenAI, Anthropic, and local models.",
-  "version": "1.0.0",
+  "description": "Complete LangChain knowledge from official documentation. Use when building LLM-powered applications with chains, agents, and RAG. Covers LangChain Python v0.3+, LCEL, LangGraph, LangSmith, and integrations with major LLM providers.",
+  "version": "1.1.0",
   "base_url": "https://python.langchain.com/docs/",
   "sources": [
     {
       "type": "documentation",
       "base_url": "https://python.langchain.com/docs/",
       "start_urls": [
-        "https://python.langchain.com/docs/get_started/introduction",
-        "https://python.langchain.com/docs/expression_language/",
-        "https://python.langchain.com/docs/modules/model_io/",
-        "https://python.langchain.com/docs/modules/agents/",
-        "https://python.langchain.com/docs/use_cases/question_answering/"
+        "https://python.langchain.com/docs/introduction/",
+        "https://python.langchain.com/docs/concepts/",
+        "https://python.langchain.com/docs/how_to/",
+        "https://python.langchain.com/docs/tutorials/",
+        "https://python.langchain.com/docs/integrations/providers/"
       ],
       "selectors": {
         "main_content": "article, main",
@@ -21,82 +21,158 @@
       },
       "url_patterns": {
         "include": [
-          "/docs/get_started/",
-          "/docs/expression_language/",
-          "/docs/modules/",
-          "/docs/use_cases/",
+          "/docs/introduction/",
+          "/docs/concepts/",
+          "/docs/how_to/",
+          "/docs/tutorials/",
           "/docs/integrations/"
         ],
         "exclude": [
-          "/docs/changelog/"
+          "/docs/additional_resources/",
+          "/docs/versions/"
         ]
       },
       "categories": {
         "getting_started": [
           "introduction",
-          "quickstart",
           "installation",
+          "quickstart",
           "setup"
         ],
-        "expression_language": [
-          "expression-language",
+        "concepts": [
+          "concepts",
+          "runnables",
           "lcel",
-          "runnable",
-          "pipe",
-          "chain"
+          "messages",
+          "chat_models",
+          "llms",
+          "output_parsers"
+        ],
+        "expression_language": [
+          "lcel",
+          "runnable-interface",
+          "runnable-parallel",
+          "runnable-passthrough",
+          "streaming"
         ],
         "models": [
           "chat-models",
           "llms",
           "openai",
           "anthropic",
-          "local",
-          "streaming"
+          "ollama",
+          "azure",
+          "google"
         ],
         "prompts": [
-          "prompts",
-          "templates",
+          "prompt-templates",
+          "chat-prompt-templates",
           "few-shot",
           "example-selectors"
         ],
-        "indexes": [
+        "document_loaders": [
           "document-loaders",
           "text-splitters",
+          "csv",
+          "pdf",
+          "web"
+        ],
+        "vector_stores": [
           "vector-stores",
+          "retrievers",
           "embeddings",
-          "retrievers"
+          "chroma",
+          "pinecone",
+          "faiss"
         ],
         "chains": [
-          "chains",
-          "llm-chain",
+          "rag",
           "retrieval",
-          "conversational",
+          "conversational-rag",
+          "summarization",
           "sql"
         ],
         "agents": [
           "agents",
           "tools",
           "toolkits",
-          "agent-executor",
-          "plan-and-execute"
+          "react",
+          "openai-tools"
         ],
         "memory": [
           "memory",
-          "buffer",
-          "summary",
-          "vectorstore"
+          "conversation-buffer",
+          "chat-history",
+          "checkpointing"
         ],
         "use_cases": [
-          "qa",
+          "qa-chat-history",
           "chatbots",
           "rag",
           "extraction",
           "sql",
-          "api"
+          "code-writing"
+        ],
+        "output_parsing": [
+          "output-parsers",
+          "structured-output",
+          "json",
+          "pydantic"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
+    },
+    {
+      "type": "documentation",
+      "base_url": "https://langchain-ai.github.io/langgraph/",
+      "start_urls": [
+        "https://langchain-ai.github.io/langgraph/",
+        "https://langchain-ai.github.io/langgraph/tutorials/introduction/",
+        "https://langchain-ai.github.io/langgraph/concepts/"
+      ],
+      "selectors": {
+        "main_content": "article, main",
+        "title": "h1",
+        "code_blocks": "pre code, pre"
+      },
+      "url_patterns": {
+        "include": [
+          "/langgraph/",
+          "/langgraph/tutorials/",
+          "/langgraph/concepts/",
+          "/langgraph/how-tos/"
+        ],
+        "exclude": [
+          "/langgraph/reference/"
+        ]
+      },
+      "categories": {
+        "langgraph_intro": [
+          "tutorials/introduction",
+          "concepts/why-langgraph",
+          "quickstart"
+        ],
+        "langgraph_concepts": [
+          "concepts/low_level",
+          "state",
+          "nodes",
+          "edges",
+          "graphs"
+        ],
+        "langgraph_agents": [
+          "how-tos/create-react-agent",
+          "agentic-rag",
+          "human-in-the-loop",
+          "multi-agent"
+        ],
+        "langgraph_persistence": [
+          "concepts/persistence",
+          "checkpointers",
+          "memory",
+          "store"
+        ]
+      },
+      "rate_limit": 0.3
     }
   ],
   "metadata": {
@@ -108,13 +184,15 @@
       "RAG systems",
       "AI agents",
       "Chatbots",
-      "Document Q&A"
+      "Document Q&A",
+      "Multi-agent systems"
     ],
     "related_skills": [
       "openai-api",
       "python",
       "vector-databases",
-      "anthropic"
+      "anthropic",
+      "langgraph"
     ]
   }
 }

--- a/official/ai-ml/lightgbm.json
+++ b/official/ai-ml/lightgbm.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "Installation-Guide",
           "Quick-Start",
           "Python-Intro"
@@ -99,8 +98,7 @@
           "model_to_string"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 300
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/llamaindex.json
+++ b/official/ai-ml/llamaindex.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "getting_started/installation",
           "starter_example",
           "concepts"
@@ -115,8 +114,7 @@
           "retrieval_evaluation"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 600
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/matplotlib.json
+++ b/official/ai-ml/matplotlib.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "users/getting_started",
           "users/installing",
           "api/pyplot_summary"
@@ -103,8 +102,7 @@
           "bbox"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 600
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/mlflow.json
+++ b/official/ai-ml/mlflow.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "quickstart",
           "introduction",
           "installation"
@@ -118,8 +117,7 @@
           "prompt-management"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/modin.json
+++ b/official/ai-ml/modin.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "getting_started/quickstart",
           "installation",
           "why_modin"
@@ -91,8 +90,7 @@
           "progress_bar"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 250
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/nltk.json
+++ b/official/ai-ml/nltk.json
@@ -20,7 +20,6 @@
       },
       "url_patterns": {
         "include": [
-          "/",
           "/book/",
           "/api/",
           "/howto/"
@@ -31,7 +30,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "book/ch00",
           "install",
           "download"
@@ -113,8 +111,7 @@
           "model"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/ollama.json
+++ b/official/ai-ml/ollama.json
@@ -1,32 +1,36 @@
 {
   "name": "ollama",
-  "description": "Complete Ollama knowledge from official documentation. Use when running LLMs locally. Covers model pulling, chatting, custom models, Modelfile, and REST API.",
-  "version": "1.0.0",
-  "base_url": "https://github.com/ollama/ollama/blob/main/README.md",
+  "description": "Complete Ollama knowledge from official documentation. Use when running LLMs locally. Covers model pulling, chatting, custom models, Modelfile, REST API, OpenAI-compatible API, and GPU setup.",
+  "version": "1.1.0",
+  "base_url": "https://github.com/ollama/ollama",
   "sources": [
     {
       "type": "documentation",
-      "base_url": "https://github.com/ollama/ollama/blob/main/README.md",
+      "base_url": "https://github.com/ollama/ollama/blob/main/",
       "start_urls": [
         "https://github.com/ollama/ollama/blob/main/README.md",
-        "https://github.com/ollama/ollama/blob/main/docs/API.md",
+        "https://github.com/ollama/ollama/blob/main/docs/api.md",
         "https://github.com/ollama/ollama/blob/main/docs/modelfile.md",
-        "https://ollama.com/library"
+        "https://github.com/ollama/ollama/blob/main/docs/linux.md",
+        "https://github.com/ollama/ollama/blob/main/docs/gpu.md",
+        "https://github.com/ollama/ollama/blob/main/docs/faq.md",
+        "https://github.com/ollama/ollama/blob/main/docs/import.md",
+        "https://github.com/ollama/ollama/blob/main/docs/openai.md",
+        "https://github.com/ollama/ollama/blob/main/docs/tutorials/"
       ],
       "selectors": {
-        "main_content": "article, main, .readme",
+        "main_content": "article, main, .readme, [data-target='readme-toc.content']",
         "title": "h1",
         "code_blocks": "pre code, pre"
       },
       "url_patterns": {
         "include": [
           "/ollama/ollama/blob/main/",
-          "/ollama/ollama/blob/main/docs/",
-          "/ollama/ollama/blob/main/docs/API.md",
-          "/ollama/ollama/blob/main/docs/modelfile.md"
+          "/ollama/ollama/blob/main/docs/"
         ],
         "exclude": [
-          "/ollama/ollama/blob/main/CHANGELOG.md"
+          "/ollama/ollama/blob/main/CHANGELOG.md",
+          "/ollama/ollama/blob/main/.github/"
         ]
       },
       "categories": {
@@ -43,7 +47,8 @@
           "list",
           "rm",
           "cp",
-          "push"
+          "push",
+          "serve"
         ],
         "modelfile": [
           "modelfile",
@@ -51,15 +56,27 @@
           "PARAMETER",
           "TEMPLATE",
           "SYSTEM",
-          "ADAPTER"
+          "ADAPTER",
+          "LICENSE"
         ],
         "api": [
-          "API",
+          "api",
           "generate",
           "chat",
           "embeddings",
           "create",
-          "tags"
+          "tags",
+          "show",
+          "copy",
+          "delete",
+          "pull",
+          "push"
+        ],
+        "openai_compat": [
+          "openai",
+          "openai-compatible",
+          "v1/chat/completions",
+          "v1/models"
         ],
         "models": [
           "library",
@@ -67,7 +84,9 @@
           "mistral",
           "codellama",
           "phi",
-          "gemma"
+          "gemma",
+          "qwen",
+          "deepseek"
         ],
         "parameters": [
           "PARAMETER",
@@ -75,34 +94,43 @@
           "top_p",
           "top_k",
           "num_ctx",
-          "seed"
+          "seed",
+          "stop",
+          "repeat_penalty"
         ],
         "importing": [
           "import",
           "gguf",
           "safetensors",
-          "pytorch"
+          "pytorch",
+          "lora"
         ],
         "gpu": [
           "gpu",
+          "linux",
           "cuda",
           "rocm",
-          "metal"
+          "metal",
+          "nvidia",
+          "amd"
         ],
-        "troubleshooting": [
-          "troubleshooting",
+        "faq": [
           "faq",
-          "common-issues"
+          "troubleshooting",
+          "common-issues",
+          "proxy",
+          "environment-variables"
         ],
         "integrations": [
           "integrations",
           "langchain",
           "llamaindex",
-          "open-webui"
+          "open-webui",
+          "python",
+          "javascript"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 150
+      "rate_limit": 0.3
     }
   ],
   "metadata": {
@@ -114,14 +142,15 @@
       "Private AI",
       "Model experimentation",
       "Edge AI",
-      "Offline inference"
+      "Offline inference",
+      "OpenAI-compatible local API"
     ],
     "related_skills": [
       "docker",
       "python",
       "langchain",
       "llamacpp",
-      "ggml"
+      "openai-api"
     ]
   }
 }

--- a/official/ai-ml/onnx.json
+++ b/official/ai-ml/onnx.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "onnx/intro",
           "docs/get-started",
           "overview"
@@ -99,8 +98,7 @@
           "pretrained-models"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/openai-api.json
+++ b/official/ai-ml/openai-api.json
@@ -1,7 +1,7 @@
 {
   "name": "openai-api",
-  "description": "Complete OpenAI API knowledge from official documentation. Use when integrating GPT models, DALL-E, Whisper, or embedding models into applications. Covers API v1, function calling, fine-tuning, and best practices.",
-  "version": "1.0.0",
+  "description": "Complete OpenAI API knowledge from official documentation. Use when integrating GPT-4o, o1, o3, DALL-E, Whisper, or embedding models into applications. Covers Responses API, function calling, structured outputs, fine-tuning, realtime, and best practices.",
+  "version": "1.1.0",
   "base_url": "https://platform.openai.com/docs/",
   "sources": [
     {
@@ -12,7 +12,9 @@
         "https://platform.openai.com/docs/api-reference",
         "https://platform.openai.com/docs/guides/text-generation",
         "https://platform.openai.com/docs/guides/function-calling",
-        "https://platform.openai.com/docs/guides/embeddings"
+        "https://platform.openai.com/docs/guides/embeddings",
+        "https://platform.openai.com/docs/guides/structured-outputs",
+        "https://platform.openai.com/docs/guides/realtime"
       ],
       "selectors": {
         "main_content": "main, article, .docs-content",
@@ -42,42 +44,60 @@
         ],
         "models": [
           "models",
-          "gpt-4",
-          "gpt-3.5",
+          "gpt-4o",
+          "gpt-4o-mini",
+          "gpt-4.1",
+          "o1",
+          "o1-mini",
+          "o3",
+          "o3-mini",
           "dall-e",
           "whisper",
-          "embeddings",
-          "moderation"
+          "text-embedding"
         ],
         "text_generation": [
           "chat-completions",
-          "completions",
           "prompt-engineering",
           "system-prompts",
-          "streaming"
+          "streaming",
+          "temperature"
+        ],
+        "responses_api": [
+          "responses",
+          "response-api",
+          "stateful",
+          "context-window"
         ],
         "function_calling": [
           "function-calling",
           "tools",
+          "tool-choice",
           "parallel-functions",
           "forced-function"
+        ],
+        "structured_outputs": [
+          "structured-outputs",
+          "json-mode",
+          "response-format",
+          "json-schema"
         ],
         "embeddings": [
           "embeddings",
           "vector",
           "similarity",
           "clustering",
-          "text-embedding"
+          "text-embedding-3"
         ],
         "fine_tuning": [
           "fine-tuning",
           "training",
           "dataset",
-          "hyperparameters"
+          "hyperparameters",
+          "dpo"
         ],
         "images": [
           "images",
-          "dall-e",
+          "dall-e-3",
           "generation",
           "editing",
           "variations"
@@ -87,14 +107,28 @@
           "whisper",
           "transcription",
           "translation",
-          "text-to-speech"
+          "text-to-speech",
+          "tts-1"
+        ],
+        "realtime_api": [
+          "realtime",
+          "websocket",
+          "voice",
+          "audio-streaming"
         ],
         "assistants": [
           "assistants",
           "threads",
           "messages",
           "runs",
-          "files"
+          "file-search",
+          "code-interpreter"
+        ],
+        "vector_stores": [
+          "vector-stores",
+          "file-search",
+          "retrieval",
+          "uploads"
         ],
         "api_reference": [
           "api-reference",
@@ -108,11 +142,10 @@
           "rate-limits",
           "error-handling",
           "retrying",
-          "streaming"
+          "latency"
         ]
       },
-      "rate_limit": 0.5,
-      "max_pages": 300
+      "rate_limit": 0.5
     }
   ],
   "metadata": {
@@ -125,13 +158,15 @@
       "Code assistance",
       "Image generation",
       "Speech-to-text",
-      "Semantic search"
+      "Semantic search",
+      "Realtime voice AI"
     ],
     "related_skills": [
       "python",
       "javascript",
       "langchain",
-      "vector-databases"
+      "vector-databases",
+      "anthropic"
     ]
   }
 }

--- a/official/ai-ml/opencv.json
+++ b/official/ai-ml/opencv.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "tutorial_root",
           "introduction",
           "installation"
@@ -119,8 +118,7 @@
           "neural-networks"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 600
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/pinecone.json
+++ b/official/ai-ml/pinecone.json
@@ -33,7 +33,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "guides/getting-started",
           "quickstart",
           "overview"
@@ -107,8 +106,7 @@
           "alerts"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 300
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/plotly.json
+++ b/official/ai-ml/plotly.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "getting-started",
           "installation",
           "chart-studio"
@@ -119,8 +118,7 @@
           "pdf"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/pytorch-lightning.json
+++ b/official/ai-ml/pytorch-lightning.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "starter/introduction",
           "starter/converting",
           "starter/installation"
@@ -107,8 +106,7 @@
           "run"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 450
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/ray.json
+++ b/official/ai-ml/ray.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "ray-overview",
           "installation",
           "quickstart"
@@ -105,8 +104,7 @@
           "profiling"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 600
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/scikit-learn.json
+++ b/official/ai-ml/scikit-learn.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "user_guide",
           "install",
           "faq"
@@ -105,8 +104,7 @@
           "ovo"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 500
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/seaborn.json
+++ b/official/ai-ml/seaborn.json
@@ -20,9 +20,8 @@
       },
       "url_patterns": {
         "include": [
-          "/",
-          "/tutorial.html",
-          "/api.html",
+          "/tutorial/",
+          "/api/",
           "/examples/",
           "/generated/"
         ],
@@ -32,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "installation",
           "introduction",
           "tutorial/function_overview"
@@ -109,8 +107,7 @@
           "figure-size"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 350
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/spacy.json
+++ b/official/ai-ml/spacy.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "spacy-101",
           "installation",
           "models"
@@ -108,8 +107,7 @@
           "msgpack"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 400
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/vllm.json
+++ b/official/ai-ml/vllm.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "getting_started/quickstart",
           "installation",
           "requirements"
@@ -96,8 +95,7 @@
           "adapter"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 250
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/wandb.json
+++ b/official/ai-ml/wandb.json
@@ -33,7 +33,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "quickstart",
           "install",
           "init"
@@ -111,8 +110,7 @@
           "deploy"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 350
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/weaviate.json
+++ b/official/ai-ml/weaviate.json
@@ -32,7 +32,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "quickstart",
           "installation",
           "core-concepts"
@@ -110,8 +109,7 @@
           "crud"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 450
+      "rate_limit": 0.3
     }
   ],
   "metadata": {

--- a/official/ai-ml/xgboost.json
+++ b/official/ai-ml/xgboost.json
@@ -31,7 +31,6 @@
       },
       "categories": {
         "getting_started": [
-          "",
           "tutorials/index",
           "python/python_intro",
           "install"
@@ -110,8 +109,7 @@
           "cupy"
         ]
       },
-      "rate_limit": 0.3,
-      "max_pages": 350
+      "rate_limit": 0.3
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary

- Remove `max_pages` from all 34 ai-ml configs (was artificially limiting crawls)
- Major rewrites for 4 configs with outdated/broken information
- Minor URL pattern fixes for 5 configs
- All 34 configs pass `--dry-run` validation

## Changes by Type

### Major Rewrites
- **`anthropic.json`**: Update to current models (Claude Opus/Sonnet/Haiku 4, claude-3-7-sonnet), add `extended_thinking`, `batch_api`, `files_api`, `mcp` categories
- **`openai-api.json`**: Add current models (o1, o3, gpt-4o, gpt-4.1), add `structured_outputs`, `realtime_api`, `responses_api`, `vector_stores` categories
- **`langchain.json`**: Rewrite for v0.3+ URL structure, add LangGraph as second source with dedicated categories
- **`ollama.json`**: Fix `base_url` (was pointing to README.md file), add all docs pages, add `openai_compat` and `faq` categories

### Minor Fixes
- **`chroma.json`**: Fix `"/"` include pattern → specific paths, update start_urls for new docs structure, add `client_server` and `migration` categories
- **`seaborn.json`**: Fix `"/"` include pattern → `/tutorial/`, `/api/`, `/examples/`, `/generated/`
- **`nltk.json`**: Fix `"/"` include pattern → `/book/`, `/api/`, `/howto/`
- **`keras.json`**: Remove outdated `/keras_3/` exclusion (Keras 3 is now main version)
- **`deepspeed.json`**: Add top-level `base_url` field (was missing), remove `max_pages` from both sources

### max_pages Removed (25 configs)
catboost, cohere, dvc, fastai, gensim, huggingface, jax, kubeflow, lightgbm, llamaindex, matplotlib, mlflow, modin, onnx, opencv, pinecone, plotly, pytorch-lightning, ray, scikit-learn, spacy, vllm, wandb, weaviate, xgboost

## Test plan
- [x] All 34 configs pass `skill-seekers scrape --config <file> --dry-run`
- [x] No `max_pages` remaining in any ai-ml config

🤖 Generated with [Claude Code](https://claude.com/claude-code)